### PR TITLE
Make compatible with recent node versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+package-lock.json

--- a/index.js
+++ b/index.js
@@ -1,6 +1,8 @@
 var protein = require('protein');
 var murl = require('murl');
 var address = require('network-address');
+var inherits = require('inherits');
+var events = require('events');
 
 var METHODS = 'GET HEAD POST PUT DELETE PATCH OPTIONS'.split(' ');
 var ALIASES = {};
@@ -24,7 +26,7 @@ var Root = function() {
 	this.setMaxListeners(0);
 };
 
-Root.prototype.__proto__ = process.EventEmitter.prototype;
+inherits(Root, events.EventEmitter)
 
 Root.prototype.use = function(arg) {
 	if (typeof arg === 'function') {
@@ -210,7 +212,7 @@ Root.prototype.route = function(request, response, callback) {
 			url = decodeURL(request.url);
 			if (!url) return response.error(400, 'url is malformed');
 		}
-		
+
 		for (i++; i < entries.length && !(request.params = entries[i].pattern(url)); i++);
 		if (!entries[i]) return callback();
 

--- a/package.json
+++ b/package.json
@@ -2,9 +2,10 @@
   "name": "root",
   "version": "3.1.0",
   "dependencies": {
+    "inherits": "^2.0.3",
     "murl": "0.4.x",
-    "protein": "0.5.x",
-    "network-address": "0.0.x"
+    "network-address": "0.0.x",
+    "protein": "0.5.x"
   },
   "repository": "git://github.com/mafintosh/root",
   "description": "a super lightweight web framework featuring prototype mixin support and routing",

--- a/tests/test-urls.js
+++ b/tests/test-urls.js
@@ -2,6 +2,7 @@ var assert = require('assert');
 var exec = require('child_process').exec;
 var root = require('../index');
 var app = root();
+var events = require('events');
 
 var ran = 0;
 var index = false;
@@ -26,8 +27,8 @@ app.get('/c/*', function(req, res) {
 });
 
 var test = function(url) {
-	var req = new process.EventEmitter();
-	var res = new process.EventEmitter();
+	var req = new events.EventEmitter();
+	var res = new events.EventEmitter();
 
 	req.method = 'GET';
 	req.url = url;


### PR DESCRIPTION
Currently root is not compatible with recent versions of node.

This moves to using `events` and `inherits` to increase compatibility. With this commit, root is compatible node LTS.